### PR TITLE
add new label "starter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create a standard set of issue labels for a GitHub project
 ```txt
 duplicate:             ededed
 greenkeeper:           ededed
+starter                ffc0cb
 Priority: Critical:    ee0701
 Priority: High:        d93f0b
 Priority: Low:         0e8a16

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var request = require('request')
 var colors = {
   'duplicate': 'ededed',
   'greenkeeper': 'ededed',
+  'starter': 'ffc0cb',
   'Priority: Critical': 'ee0701',
   'Priority: High': 'd93f0b',
   'Priority: Low': '0e8a16',


### PR DESCRIPTION
Fixes: https://github.com/yoshuawuyts/github-standard-labels/issues/4. It's nice to have a "starter" label to encourage new contributors to get involved ;)


Note: This order is not alphabetical, but it's good at perspicuity IMO. Let me know if you'd like to keep alphabetical :)